### PR TITLE
prosody_dynamic() bug fixed in prosody.py

### DIFF
--- a/prosody/prosody.py
+++ b/prosody/prosody.py
@@ -400,7 +400,6 @@ class Prosody:
                 seg_voiced.append(VoicedSeg)
                 #Compute duration
                 dur = len(VoicedSeg)/float(fs)
-                tempvec.append(dur)
                 #Pitch coefficients
                 x = np.arange(0,len(temp))
                 z = np.poly1d(np.polyfit(x,temp,self.P))
@@ -412,6 +411,7 @@ class Prosody:
                 x = np.arange(0,len(temp))
                 z = np.poly1d(np.polyfit(x,temp,self.P))
                 tempvec.extend(z.coeffs)
+                tempvec.append(dur)
                 featvec.append(tempvec)
             iniV= pitchON[indx+1]
             iniVoiced = (pitchON[indx+1]*size_stepS)+size_stepS#To compute energy


### PR DESCRIPTION
`tempvec.append(dur)` moved from line  403 to line 414 after `tempvec.extend(z.coeffs)`.
In this way the duration of the audio segment is actually the last of the 13 features. Otherwise it would have been the first one under the name of _'f0coef0'_. This would shift all the features by one position and get them all with the wrong name.